### PR TITLE
Add error handler to request to prevent error throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ function download(url, dest, dirname) {
     var request = https.get(url, function(response) {
         response.pipe(file);
         bar.tick();
+    }).on("error", function (e) {
+        console.log("Error while downloading", url, e.code);
     });
 };
 


### PR DESCRIPTION
Regarding [my issue](https://github.com/MehediH/Bulksplash/issues/2) - it seems that adding an error handler fixes the problem *partly*. Some images are still not downloaded fully, but at least the process doesn't stop when an error occurs, allowing images that *can* be downloaded to download.