### PR TITLE
feat: add API key saving and deletion support via keytar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Available options:
 - `--j`: whether you want to generate a credits file.
 - `--k`: your Unsplash API key.
 - `--s`: whether you want to save the API key with *keytar* for future use.
+- `--r`: if you want to wipe the saved API key from *keytar*.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Available options:
 - `--n`: the name scheme of the downloaded images (0 for `authorname-randomstring`, 1 for numbered list)
 - `--j`: whether you want to generate a credits file.
 - `--k`: your Unsplash API key.
+- `--s`: whether you want to save the API key with *keytar* for future use.
 
 ---
 

--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,8 @@
+const SERVICE = 'bulksplash-cli';
+const ACCOUNT = 'bulksplash';
+
+module.exports = {
+  SERVICE,
+  ACCOUNT,
+};
+

--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ const https = require('https');
 const path = require('path');
 const ProgressBar = require('progress');
 const inquirer = require('inquirer');
+const keytar = require('keytar');
 const { firstQuestions, nextQuestions } = require('./questions');
+const { SERVICE, ACCOUNT } = require('./consts');
 
 const bulksplash = async (args) => {
   let basePath = '';
@@ -13,8 +15,19 @@ const bulksplash = async (args) => {
   const options = {};
 
   const ask = async () => {
-    await inquirer
-      .prompt([
+    let initialPrompts = [];
+    let apiKey = '';
+
+    try {
+      apiKey = await keytar.getPassword(SERVICE, ACCOUNT);
+    } catch (error) {
+      console.error(
+        '🚨 Error while retrieving the API key. Please try again or save it manually | ' + error.message
+      );
+    }
+
+    if (!apiKey) {
+      initialPrompts.push(
         {
           type: 'input',
           name: 'apiKey',
@@ -22,25 +35,48 @@ const bulksplash = async (args) => {
         },
         {
           type: 'input',
-          name: 'path',
-          message: '📂 Which directory do you want to save to?',
-          default: '.',
-        },
-        {
-          type: 'list',
-          name: 'random',
-          message: '📸 Which images do you want to download?',
-          choices: ['Random', 'From a collection'],
-          filter: function (val) {
-            return val === 'Random';
-          },
-        },
-      ])
+          name: 'shouldSaveApiKey',
+          message: '💾 Do you want to save the API key for future use? (y/n)',
+          validate: input => ['y', 'n'].includes(input.toLowerCase()) || 'Please enter y or n',
+        }
+      );
+    }
+
+    // Common prompts
+    initialPrompts.push(
+      {
+        type: 'input',
+        name: 'path',
+        message: '📂 Which directory do you want to save to?',
+        default: '.',
+      },
+      {
+        type: 'list',
+        name: 'random',
+        message: '📸 Which images do you want to download?',
+        choices: ['Random', 'From a collection'],
+        filter: val => val === 'Random',
+      }
+    );
+
+    await inquirer
+      .prompt(initialPrompts)
       .then((answers) => {
         options.random = answers.random;
         options.apiKey = answers.apiKey;
+        options.shouldSaveApiKey = answers.shouldSaveApiKey === 'y';
         basePath = answers.path === '.' ? '' : answers.path;
       });
+
+    if (options.shouldSaveApiKey) {
+      try {
+        await keytar.setPassword(SERVICE, ACCOUNT, options.apiKey);
+      } catch (error) {
+        console.error(
+          '🚨 Error while saving the API key. Please try again or save it manually | ' + error.message
+        );
+      }
+    }
 
     if (options.random) {
       // random

--- a/index.js
+++ b/index.js
@@ -188,8 +188,21 @@ const bulksplash = async (args) => {
     options.nameScheme = args.n ? 0 : 1;
     options.saveCredits = args.j ? args.j : false;
     options.shouldSaveApiKey = args.s ? args.s : false;
+    options.shouldWipeApiKey = args.r ? args.r : false;
 
-    if (shouldSaveApiKey && !options.apiKey) {
+    if (options.shouldWipeApiKey) {
+      try {
+        keytar.deletePassword(SERVICE, ACCOUNT);
+        console.log('✅ API key has been deleted successfully.');
+      }
+      catch (error) {
+        console.error(
+          '🚨 Error while deleting the API key. Please try again or save it manually | ' + error.message
+        );
+      }
+    }
+
+    if (options.shouldSaveApiKey && !options.apiKey) {
       console.error(
         '🚨 You need to provide an API key with the --k flag or save it manually.'
       );

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const bulksplash = async (args) => {
           name: 'shouldSaveApiKey',
           message: '💾 Do you want to save the API key for future use? (y/n)',
           validate: input => ['y', 'n'].includes(input.toLowerCase()) || 'Please enter y or n',
+          default: 'n',
         }
       );
     }
@@ -186,6 +187,22 @@ const bulksplash = async (args) => {
     options.featured = args.f ? args.f : false;
     options.nameScheme = args.n ? 0 : 1;
     options.saveCredits = args.j ? args.j : false;
+    options.shouldSaveApiKey = args.s ? args.s : false;
+
+    if (shouldSaveApiKey && !options.apiKey) {
+      console.error(
+        '🚨 You need to provide an API key with the --k flag or save it manually.'
+      );
+      return;
+    } else if (options.shouldSaveApiKey) {
+      try {
+        keytar.setPassword(SERVICE, ACCOUNT, options.apiKey);
+      } catch (error) {
+        console.error(
+          '🚨 Error while saving the API key. Please try again or save it manually | ' + error.message
+        );
+      }
+    }
   } else {
     await ask();
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fs": "^0.0.1-security",
     "https": "^1.0.0",
     "inquirer": "^7.1.0",
+    "keytar": "^7.9.0",
     "minimist": "^1.2.8",
     "path": "^0.12.7",
     "progress": "^2.0.3",


### PR DESCRIPTION
This PR introduces secure API key handling for the CLI using the `keytar` library:

* Users can now enter and optionally save their API key securely using the system keychain (macOS Keychain, Windows Credential Vault, or libsecret on Linux).
* When no key is saved, the CLI prompts the user for the API key and whether it should be stored for future use.
* It's also possible to choose to save the inserted API key using the `--s` flag.
* They can also delete the saved API key at any time using the `--r` flag.

#### Example prompt:

```
🔑 What is your API key? sk-1234abcd...
💾 Do you want to save the API key for future use? (y/n) (default: n) y
```